### PR TITLE
Force push production deploy to Heroku

### DIFF
--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -206,7 +206,9 @@ jobs:
           echo "🚀 DEPLOYING CODE TO PRODUCTION"
           echo "=========================================="
 
-          git push heroku main:main
+          # Force push is required when the Heroku remote's main has commits
+          # not present in the GitHub checkout (e.g. previous non-FF deploys)
+          git push heroku main:main --force
 
           echo "✅ Code deployed to production"
           echo "=========================================="


### PR DESCRIPTION
The production Heroku remote can contain commits not in the GitHub checkout, causing the non-FF push to fail. This aligns with the staging deploy which already uses --force. Staging is already live on heroku-24; this only affects the production workflow deploy step.