### PR TITLE
chore: promote dependency updates + reCAPTCHA rebuild trigger to production

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,4 +1,5 @@
 import type { NextConfig } from "next";
+import path from "path";
 
 const nextConfig: NextConfig = {
   // Enable React strict mode for better development experience
@@ -19,11 +20,17 @@ const nextConfig: NextConfig = {
 
   // Turbopack configuration (Next.js 16+ default)
   turbopack: {
+    // Force the project root to the frontend directory so Turbopack does not
+    // walk up to the repository root when multiple lockfiles are present.
+    root: path.resolve(__dirname),
     // Resolve aliases for better module resolution
     resolveAlias: {
       // Add any custom aliases here if needed
     },
   },
+
+  // Keep output tracing in sync with the Turbopack root
+  outputFileTracingRoot: path.resolve(__dirname),
 
   // Configure transpilation for 3D packages
   transpilePackages: [

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ psycopg2-binary==2.9.9
 pytest==8.3.3
 pytest-cov==5.0.0
 pytest-flask==1.3.0
-python-dotenv==1.0.1
+python-dotenv==1.2.2
 pytz==2024.2
 requests==2.32.5
 SQLAlchemy==2.0.35

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ pathspec==0.12.1
 platformdirs==4.3.6
 pluggy==1.5.0
 psycopg2-binary==2.9.9
-pytest==8.3.3
+pytest==9.0.3
 pytest-cov==5.0.0
 pytest-flask==1.3.0
 python-dotenv==1.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,6 +39,6 @@ SQLAlchemy-Utils==0.41.2
 typing_extensions==4.12.2
 visitor==0.1.3
 Werkzeug==3.0.3
-cryptography==48.0.1
-pyOpenSSL==24.0.0
+cryptography==49.0.0
+pyOpenSSL==26.3.0
 WTForms==3.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ gunicorn==23.0.0
 iniconfig==2.0.0
 itsdangerous==2.2.0
 Jinja2==3.1.4
-Mako==1.3.5
+Mako==1.3.12
 MarkupSafe==2.1.5
 marshmallow==4.0.1
 marshmallow-sqlalchemy==1.4.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,7 +38,7 @@ SQLAlchemy==2.0.35
 SQLAlchemy-Utils==0.41.2
 typing_extensions==4.12.2
 visitor==0.1.3
-Werkzeug==3.0.3
+Werkzeug==3.1.6
 cryptography==42.0.5
 pyOpenSSL==24.0.0
 WTForms==3.1.2

--- a/scripts/dev.ps1
+++ b/scripts/dev.ps1
@@ -6,7 +6,6 @@
 
     If PowerShell blocks it due to execution policy, use:
     powershell -ExecutionPolicy Bypass -File .\scripts\dev.ps1
-
 #>
 
 # Colors for output
@@ -17,22 +16,82 @@ $Yellow = 'Yellow'
 
 Write-Host "Starting MyTools development servers..." -ForegroundColor $Cyan
 
+# Resolve absolute paths so the script works regardless of the caller's CWD
+$RootDir = (Resolve-Path -Path "$PSScriptRoot\..").Path
+$FrontendDir = (Resolve-Path -Path "$PSScriptRoot\..\frontend").Path
+
+# Verify required tools are available
+$Python = Get-Command "python" -ErrorAction SilentlyContinue
+$Node = Get-Command "node" -ErrorAction SilentlyContinue
+
+if (-not $Python) {
+    Write-Host "Error: python was not found in PATH." -ForegroundColor $Red
+    exit 1
+}
+if (-not $Node) {
+    Write-Host "Error: node was not found in PATH." -ForegroundColor $Red
+    exit 1
+}
+
+# Ensure the frontend has its dependencies installed
+if (-not (Test-Path -Path "$FrontendDir\node_modules" -PathType Container)) {
+    Write-Host "Error: node_modules not found in $FrontendDir. Run 'cd frontend; npm install' first." -ForegroundColor $Red
+    exit 1
+}
+
 # Store the original location so we can return on cleanup
 $OriginalLocation = Get-Location
 
 # Track process objects for cleanup
 $Processes = @()
 
+# Runaway-spawn guard: if a dev server's child process count blows past this,
+# something is stuck in a retry loop (e.g. Turbopack failing to resolve a
+# module and re-spawning a new postcss worker every attempt) rather than
+# running normally. Kill everything instead of letting it pile up processes.
+$MaxTreeProcesses = 20
+
+function Get-ProcessTreeIds {
+    param([int]$ProcessId)
+    $ids = @($ProcessId)
+    $children = Get-CimInstance Win32_Process -Filter "ParentProcessId=$ProcessId" -ErrorAction SilentlyContinue
+    foreach ($child in $children) {
+        $ids += Get-ProcessTreeIds -ProcessId $child.ProcessId
+    }
+    return $ids
+}
+
+function Stop-ProcessTree {
+    param([int]$ProcessId)
+    foreach ($id in (Get-ProcessTreeIds -ProcessId $ProcessId)) {
+        Stop-Process -Id $id -Force -ErrorAction SilentlyContinue
+    }
+}
+
 function Stop-DevServers {
     Write-Host "`nShutting down dev servers..." -ForegroundColor $Red
     foreach ($process in $Processes) {
-        if ($process -and -not $process.HasExited) {
-            Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue
+        if ($process) {
+            Stop-ProcessTree -ProcessId $process.Id
         }
     }
     Set-Location $OriginalLocation
     Write-Host "All servers stopped." -ForegroundColor $Green
     exit 0
+}
+
+function Test-RunawaySpawn {
+    foreach ($process in $Processes) {
+        if (-not $process -or $process.HasExited) { continue }
+        $treeCount = (Get-ProcessTreeIds -ProcessId $process.Id).Count
+        if ($treeCount -gt $MaxTreeProcesses) {
+            Write-Host "`n[Guard] Process tree for PID $($process.Id) has spawned $treeCount processes (limit: $MaxTreeProcesses)." -ForegroundColor $Red
+            Write-Host "[Guard] This usually means a build error is stuck retrying (e.g. a stale frontend\.next cache after a config change)." -ForegroundColor $Yellow
+            Write-Host "[Guard] Try: Remove-Item -Recurse -Force frontend\.next" -ForegroundColor $Yellow
+            return $true
+        }
+    }
+    return $false
 }
 
 # Register cleanup for common interrupt signals
@@ -41,21 +100,74 @@ $null = Register-EngineEvent -SourceIdentifier PowerShell.Exiting -Action { Stop
 try {
     # Start Flask backend
     Write-Host "[Backend] Starting Flask on http://localhost:5000" -ForegroundColor $Green
-    $FlaskProcess = Start-Process -FilePath "python" -ArgumentList "main.py" -WorkingDirectory $PSScriptRoot\.. -PassThru -NoNewWindow
+    $FlaskProcess = Start-Process -FilePath $Python.Source -ArgumentList "main.py" -WorkingDirectory $RootDir -PassThru -NoNewWindow
     $Processes += $FlaskProcess
 
-    # Start Next.js frontend
+    # Start Next.js frontend directly with node (avoids npm .cmd working-directory quirks)
     Write-Host "[Frontend] Starting Next.js on http://localhost:3000" -ForegroundColor $Green
-    $NextProcess = Start-Process -FilePath "npm" -ArgumentList "run", "dev" -WorkingDirectory "$PSScriptRoot\..\frontend" -PassThru -NoNewWindow
+    $NextProcess = Start-Process -FilePath $Node.Source -ArgumentList "node_modules/next/dist/bin/next", "dev" -WorkingDirectory $FrontendDir -PassThru -NoNewWindow
     $Processes += $NextProcess
 
-    Write-Host "Both servers running. Press Ctrl+C to stop." -ForegroundColor $Cyan
+    # Wait for the servers to be reachable
+    $Timeout = 60
+    $BackendReady = $false
+    $FrontendReady = $false
+    $Elapsed = 0
 
-    # Wait for either process to exit
+    while ($Elapsed -lt $Timeout -and (-not $BackendReady -or -not $FrontendReady)) {
+        Start-Sleep -Seconds 1
+        $Elapsed++
+
+        if (Test-RunawaySpawn) {
+            Write-Host "Aborting startup and killing all spawned processes..." -ForegroundColor $Red
+            Stop-DevServers
+        }
+
+        if (-not $BackendReady) {
+            try {
+                $null = Invoke-RestMethod -Uri "http://127.0.0.1:5000/health/ping" -Method GET -ErrorAction SilentlyContinue
+                $BackendReady = $true
+                Write-Host "[Backend] Ready at http://localhost:5000" -ForegroundColor $Green
+            } catch { }
+        }
+
+        if (-not $FrontendReady) {
+            try {
+                # Next.js root will return HTTP 200 once the dev server is listening
+                $null = Invoke-WebRequest -Uri "http://127.0.0.1:3000" -Method GET -UseBasicParsing -ErrorAction SilentlyContinue
+                $FrontendReady = $true
+                Write-Host "[Frontend] Ready at http://localhost:3000" -ForegroundColor $Green
+            } catch { }
+        }
+    }
+
+    if (-not $BackendReady) {
+        Write-Host "[Backend] Did not become ready within $Timeout seconds." -ForegroundColor $Yellow
+    }
+    if (-not $FrontendReady) {
+        Write-Host "[Frontend] Did not become ready within $Timeout seconds." -ForegroundColor $Yellow
+    }
+
+    Write-Host "Press Ctrl+C to stop." -ForegroundColor $Cyan
+
+    # Wait for either process to exit, or for a runaway spawn to be detected
     $Exited = $null
+    $GuardCheckCounter = 0
     while ($Exited -eq $null) {
         $Exited = $Processes | Where-Object { $_.HasExited } | Select-Object -First 1
         if ($Exited) { break }
+
+        # Checking the full process tree on every 500ms tick is wasteful;
+        # once a second is plenty to catch a runaway before it piles up.
+        $GuardCheckCounter++
+        if ($GuardCheckCounter -ge 2) {
+            $GuardCheckCounter = 0
+            if (Test-RunawaySpawn) {
+                Write-Host "Killing all spawned processes..." -ForegroundColor $Red
+                Stop-DevServers
+            }
+        }
+
         Start-Sleep -Milliseconds 500
     }
 

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -7,14 +7,45 @@
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 CYAN='\033[0;36m'
+YELLOW='\033[1;33m'
 NC='\033[0m' # No Color
 
 echo -e "${CYAN}Starting MyTools development servers...${NC}"
 
+# Runaway-spawn guard: if a dev server's descendant process count blows past
+# this, something is stuck in a retry loop (e.g. Turbopack failing to resolve
+# a module and re-spawning a new postcss worker every attempt) rather than
+# running normally. Kill everything instead of letting it pile up processes.
+MAX_TREE_PROCESSES=20
+
+# Collect a PID and all of its descendants (recursively), since `kill` on a
+# parent PID does not kill children when job control isn't active - the
+# backgrounded `cd frontend && npm run dev` subshell, npm, and the `next dev`
+# process it spawns are all separate PIDs that survive a plain `kill $PID`.
+# Uses `ps -ef` (not pgrep, which isn't available in Git Bash/Cygwin) - PID is
+# column 2 and PPID is column 3 in the -ef format on Linux, macOS, and Cygwin.
+process_tree_pids() {
+    local pid=$1
+    local pids=("$pid")
+    local child
+    for child in $(ps -ef | awk -v ppid="$pid" 'NR>1 && $3==ppid {print $2}'); do
+        pids+=($(process_tree_pids "$child"))
+    done
+    echo "${pids[@]}"
+}
+
+kill_process_tree() {
+    local pid=$1
+    local tree_pids
+    tree_pids=$(process_tree_pids "$pid")
+    kill $tree_pids 2>/dev/null
+}
+
 # Kill child processes on exit
 cleanup() {
     echo -e "\n${RED}Shutting down dev servers...${NC}"
-    kill $FLASK_PID $NEXT_PID 2>/dev/null
+    kill_process_tree "$FLASK_PID"
+    kill_process_tree "$NEXT_PID"
     wait $FLASK_PID $NEXT_PID 2>/dev/null
     echo -e "${GREEN}All servers stopped.${NC}"
     exit 0
@@ -30,10 +61,24 @@ FLASK_PID=$!
 echo -e "${GREEN}[Frontend]${NC} Starting Next.js on http://localhost:3000"
 cd frontend && npm run dev &
 NEXT_PID=$!
+cd ..
 
 echo -e "${CYAN}Both servers running. Press Ctrl+C to stop.${NC}"
 
-# Wait for either process to exit
-wait -n $FLASK_PID $NEXT_PID
+# Watch for either process exiting, or a runaway spawn from either process's
+# tree, while both are up.
+while kill -0 "$FLASK_PID" 2>/dev/null && kill -0 "$NEXT_PID" 2>/dev/null; do
+    for pid in "$FLASK_PID" "$NEXT_PID"; do
+        tree_count=$(process_tree_pids "$pid" | wc -w)
+        if [ "$tree_count" -gt "$MAX_TREE_PROCESSES" ]; then
+            echo -e "\n${RED}[Guard] Process tree for PID $pid has spawned $tree_count processes (limit: $MAX_TREE_PROCESSES).${NC}"
+            echo -e "${YELLOW}[Guard] This usually means a build error is stuck retrying (e.g. a stale frontend/.next cache after a config change).${NC}"
+            echo -e "${YELLOW}[Guard] Try: rm -rf frontend/.next${NC}"
+            cleanup
+        fi
+    done
+    sleep 1
+done
+
 echo -e "${RED}A server exited unexpectedly. Shutting down...${NC}"
 cleanup


### PR DESCRIPTION
## Summary
- Fixes the reCAPTCHA "Invalid key type" error on staging/production: NEXT_PUBLIC_RECAPTCHA_SITE_KEY is baked at Next.js build time, and a stale build was serving an old, wrong-type key even though the Heroku config var was already correct. This PR includes an empty commit that forces a fresh build to re-bake the current (correct) key.
- Resolves the cryptography/pyOpenSSL dependency conflict that was blocking the production deploy workflow (authlib 1.6.12's cryptography 48.0.1 vs pyOpenSSL 24.0.0's cap of cryptography<43). Bumped to cryptography==49.0.0 + pyOpenSSL==26.3.0, the only mutually-compatible pair currently available.
- Merges in 4 dependabot bumps validated on staging: python-dotenv 1.2.2, Mako 1.3.12, Werkzeug 3.1.6, pytest 9.0.3 (full 165-test suite re-verified locally against pytest 9 before merging — no breakage, only pre-existing SQLAlchemy/datetime deprecation warnings).
- All changes were merged into `development` first and verified via the CI test job + staging deploy job on each push before being included here.

## Test plan
- [x] CI `test` job passed on every incremental merge into development
- [x] `deploy-to-staging` succeeded on every incremental merge
- [x] Full pytest suite (165 tests) re-run locally under pytest 9.0.3 in an isolated venv — all passing
- [ ] `deploy-to-production` workflow succeeds after merge (triggered automatically on merge to main)
- [ ] Verify reCAPTCHA checkbox renders correctly on production after deploy