### PR TITLE
Fix stale footer/meta-description copy claim

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -18,7 +18,7 @@ const inter = Inter({
 
 export const metadata: Metadata = {
   title: "The Omnitool",
-  description: "A high-performance utility toolkit with 3D visualization",
+  description: "Simple tools, smarter workflows — tax calculators, email templates, and everyday utilities, free in one place.",
 };
 
 export default function RootLayout({

--- a/frontend/src/components/layout/Footer.tsx
+++ b/frontend/src/components/layout/Footer.tsx
@@ -49,7 +49,7 @@ export function Footer() {
               The Omnitool
             </Link>
             <p className="mt-4 text-text-muted text-sm">
-              A high-performance utility toolkit with 3D visualization.
+              Simple tools, smarter workflows.
             </p>
             {/* Social Links */}
             <div className="flex gap-4 mt-6">


### PR DESCRIPTION
## Summary
- Footer tagline and site meta description still had the "high-performance utility toolkit with 3D visualization" claim removed from the hero in v1.5.1
- Aligns both with the current hero tagline ("Simple tools, smarter workflows")

## Test plan
- [x] `npm run lint` — 0 errors