### PR TITLE
Release v1.5.3: fix heroku run argument passing that failed the v1.5.2 verify step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -223,7 +223,7 @@ jobs:
           HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
           FLASK_ENV: staging
         run: |
-          heroku run --exit-code python scripts/migrate_db.py -a omnitool-by-xdv-staging
+          heroku run -a omnitool-by-xdv-staging --exit-code -- python scripts/migrate_db.py
 
       - name: Import Tool Access Permissions
         env:
@@ -231,10 +231,10 @@ jobs:
         run: |
           echo "Importing tool_access permissions from dev export..."
           if [ -f "data/tool_access_exports/dev_tool_access.json" ]; then
-            heroku run --exit-code python scripts/import_tool_access.py \
+            heroku run -a omnitool-by-xdv-staging --exit-code -- \
+              python scripts/import_tool_access.py \
               --source data/tool_access_exports/dev_tool_access.json \
-              --mode merge \
-              -a omnitool-by-xdv-staging
+              --mode merge
             echo "✅ Tool access permissions imported"
           else
             echo "⚠️  No dev_tool_access.json found. Skipping tool access import."
@@ -246,7 +246,7 @@ jobs:
           HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
         run: |
           echo "Running post-deployment verification..."
-          heroku run --exit-code python scripts/verify_migration.py --env staging -a omnitool-by-xdv-staging || echo "[WARNING] Verification had failures - check output above"
+          heroku run -a omnitool-by-xdv-staging --exit-code -- python scripts/verify_migration.py --env staging || echo "[WARNING] Verification had failures - check output above"
 
       - name: Verify Dual-Stack Health
         env:

--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -256,7 +256,7 @@ jobs:
           # Run migrate_db.py which includes:
           # 1. Schema migrations (Flask-Migrate)
           # 2. Tool synchronization (sync_tools.py)
-          heroku run --exit-code python scripts/migrate_db.py -a omnitool-by-xdv
+          heroku run -a omnitool-by-xdv --exit-code -- python scripts/migrate_db.py
 
           echo "✅ Database migrations completed"
           echo "=========================================="
@@ -273,10 +273,10 @@ jobs:
           # Use the dev export (which was tested in staging)
           # In production, we import in MERGE mode (never overwrite)
           if [ -f "data/tool_access_exports/dev_tool_access.json" ]; then
-            heroku run --exit-code python scripts/import_tool_access.py \
+            heroku run -a omnitool-by-xdv --exit-code -- \
+              python scripts/import_tool_access.py \
               --source data/tool_access_exports/dev_tool_access.json \
-              --mode merge \
-              -a omnitool-by-xdv
+              --mode merge
 
             echo "✅ Tool access permissions imported (merge mode)"
           else
@@ -297,7 +297,7 @@ jobs:
           echo "=========================================="
 
           # Run verification checks
-          heroku run --exit-code python scripts/verify_migration.py --env production -a omnitool-by-xdv || {
+          heroku run -a omnitool-by-xdv --exit-code -- python scripts/verify_migration.py --env production || {
             echo "❌ VERIFICATION FAILED"
             echo "⚠️  Production may have issues - investigate immediately"
             echo "Rollback command: python scripts/rollback_migration.py --env production"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to this project will be documented in this file.
 
 
+## [1.5.3] - 2026-08-09
+### 🔧 Deploy Pipeline: Fix Argument Passing to `heroku run`
+
+Follow-up to v1.5.2. The v1.5.2 production deploy shipped successfully (app deployed, migrations applied, smoke tests green) but the pipeline then reported **failure** at "Verify Migration" — a third instance of the same class of bug, revealed only because v1.5.2 made `heroku run` failures visible for the first time.
+
+### 🐛 Fixed
+- **`heroku run` swallowed script arguments**: in `heroku run --exit-code python scripts/verify_migration.py --env production -a omnitool-by-xdv`, the Heroku CLI parsed `--env production` as its *own* flag (it warns `env flag production appears invalid`) instead of passing it to the script. `verify_migration.py` then fell back to its `--env local` default, tried to open a nonexistent SQLite file on the dyno, and reported failures that had nothing to do with production
+- All `heroku run` invocations in both workflows now use the `-a <app> --exit-code -- <command>` form, where `--` ends CLI flag parsing. This idiom was already used correctly at one call site in `deploy_production.yml`; it is now applied consistently to the migrate, import, and verify steps
+- Staging was affected identically — its verify step passed bogus args too, but the failure was masked by a `|| echo "[WARNING]"` fallback, so staging verification had been silently meaningless
+
+Verified against live production with the corrected command: **8 passed, 0 warnings, 0 failed**. No application code changed in this release.
+
+**Developer**: Xyrus De Vera
+
+
 ## [1.5.2] - 2026-08-09
 ### 🚑 Production Outage Repair, Deploy Pipeline Fix & Security Dependency Updates
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-MyTools (The Omnitool) is a Flask-based web application providing various utility tools (tax calculators, character counter, email templates, etc.) with role-based access control. Current version: 1.5.2
+MyTools (The Omnitool) is a Flask-based web application providing various utility tools (tax calculators, character counter, email templates, etc.) with role-based access control. Current version: 1.5.3
 
 ## Frontend Design System (Production — Authoritative)
 
@@ -769,6 +769,7 @@ The CI/CD pipeline (`.github/workflows/deploy.yml`) implements automatic rollbac
 5. **Template loading**: Both `templates/` and `Tools/templates/` are searched via ChoiceLoader
 6. **Role spelling mismatch**: The backend stores/serializes the SuperAdmin role as the SQLAlchemy polymorphic identity `"super_admin"` (underscore, see `model/users.py`), but the frontend's role union and every UI check use `"superadmin"` (no underscore). If you add a new place that reads `user.role` from the API, normalize it — see `to_frontend_role`/`to_backend_role` in `services/admin_service.py` (backend) and `normalizeUser` in `frontend/src/lib/api/auth.ts` (frontend). Skipping this makes SuperAdmin-only UI silently fail to render, since `role === "superadmin"` is always `false` for the raw API value.
 7. **Orphaned Alembic revisions after the history squash**: The migration history was squashed into `67f370c787fd_initial_schema` (Jan 2026). Any database whose `alembic_version` still points at a pre-squash revision (e.g. `a1b2c3d4e5f6`) makes **every** Alembic command fail with "Can't locate revision" — including `flask db stamp`, so the only fix is a raw-SQL re-stamp: `UPDATE alembic_version SET version_num='67f370c787fd'` (verify the actual schema matches that baseline first), then `flask db upgrade`. This silently broke prod/staging deploys for months (v1.5.2 outage) because the workflows also ran `heroku run` without `--exit-code`, which always exits 0. Keep `--exit-code` on every `heroku run` step whose failure should fail CI.
+8. **`heroku run` eats your script's flags**: always write `heroku run -a <app> --exit-code -- python scripts/foo.py --env production`. Without the `--` separator the Heroku CLI claims flags it recognizes (`--env`, `--app`, `--size`…) for itself and never passes them to your script, which then silently runs with its *default* arguments. This made `verify_migration.py` run with `--env local` on a production dyno, check a nonexistent SQLite file, and fail a green deploy (v1.5.3).
 
 # Agent Context & Tooling
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The Omnitool (MyTools)
 
-[![Version](https://img.shields.io/badge/version-1.5.2-blue.svg)](https://github.com/iamxdv30/TheOmnitool/releases)
+[![Version](https://img.shields.io/badge/version-1.5.3-blue.svg)](https://github.com/iamxdv30/TheOmnitool/releases)
 [![Python](https://img.shields.io/badge/python-3.x-3776AB.svg?logo=python&logoColor=white)](https://www.python.org/)
 [![Flask](https://img.shields.io/badge/Flask-3.1.3-000000.svg?logo=flask&logoColor=white)](https://flask.palletsprojects.com/)
 [![Next.js](https://img.shields.io/badge/Next.js-16-000000.svg?logo=next.js&logoColor=white)](https://nextjs.org/)

--- a/VERSION
+++ b/VERSION
@@ -1,2 +1,2 @@
-Current Version: 1.5.2
-Previous Version: 1.5.1
+Current Version: 1.5.3
+Previous Version: 1.5.2


### PR DESCRIPTION
## Summary

**v1.5.3** — a one-line-class fix to how the deploy workflows invoke `heroku run`. No application code changes.

## What happened

The v1.5.2 production deploy **succeeded** — app deployed, `Run Database Migrations (Production)` passed, and production is verifiably healthy (smoke tests 6/6, Alembic at head `010860a68cea`, 4 tools with icons/categories, 28 access grants, 7 users). But the pipeline then went **red at `Verify Migration (Production)`**.

The verifier, not the deploy, was broken.

## Root cause

```
heroku run --exit-code python scripts/verify_migration.py --env production -a omnitool-by-xdv
```

The Heroku CLI parses `--env production` as **its own** flag and never forwards it to the script — it even warns `env flag production appears invalid`. `verify_migration.py` therefore fell back to its `--env local` default, tried to open a nonexistent SQLite file on the dyno, and reported failures that had nothing to do with production.

This is the third instance of the same bug class behind the original outage, and it only became visible *because* v1.5.2 stopped swallowing `heroku run` exit codes. Staging carried the identical defect, masked by its `|| echo "[WARNING]"` fallback — so staging verification had been silently meaningless too.

## Fix

All `heroku run` calls now use `-a <app> --exit-code -- <command>`. The `--` separator ends CLI flag parsing so everything after it reaches the script. This idiom was already used correctly at one call site in `deploy_production.yml`; it is now applied consistently to the migrate, import, and verify steps in both workflows.

## Verification

Ran the corrected command against **live production**:

```
Running verification for production environment...
✓ PostgreSQL health check passed: {'users': 7, 'tools': 4, 'tool_access': 28}
MIGRATION VERIFICATION RESULTS - PRODUCTION
Summary: 8 passed, 0 warnings, 0 failed
Overall Status: [PASSED]
```

Backend and frontend test jobs pass on this commit. Production smoke tests 6/6.

## Docs

CLAUDE.md gains a Common Gotchas entry on the `--` separator requirement, so the next person doesn't spend a red deploy rediscovering that `heroku run` eats `--env`.
