### PR TITLE
Release v1.5.4: serialize Heroku deploys with a shared concurrency group

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -94,6 +94,16 @@ jobs:
     needs: test
     environment: staging
 
+    # Serialized against deploy-to-production via a shared, repository-scoped
+    # concurrency group. The Heroku account is Eco tier, which permits only one
+    # one-off dyno at a time across ALL apps, so overlapping deploys make the
+    # second one's `heroku run` steps die with "Cannot run more than 1 Eco size
+    # dynos". Queue instead of cancelling - a half-finished deploy is worse than
+    # a slow one. Scoped to this job so `test` still runs in parallel.
+    concurrency:
+      group: heroku-one-off-dyno
+      cancel-in-progress: false
+
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3

--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -46,6 +46,15 @@ jobs:
       # This creates a manual approval gate in GitHub
       # Requires repository settings: Settings > Environments > production > Required reviewers
 
+    # Shares the `heroku-one-off-dyno` group with deploy-to-staging in
+    # deploy.yml. Concurrency groups are repository-scoped, so naming the same
+    # group in both workflows makes them queue behind each other instead of
+    # competing for the single Eco-tier one-off dyno. Never cancel in progress:
+    # aborting mid-migration is the failure mode we are protecting against.
+    concurrency:
+      group: heroku-one-off-dyno
+      cancel-in-progress: false
+
     steps:
       - name: Production Deployment Notice
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 
 
+## [1.5.4] - 2026-08-09
+### 🔒 Deploy Pipeline: Serialize Heroku Deploys
+
+Removes the last known source of spurious deploy failures. No application code changed.
+
+### 🐛 Fixed
+- **Overlapping deploys no longer collide over the single Eco one-off dyno.** The Heroku account is Eco tier, which allows only one one-off dyno at a time *across all apps*. When the staging and production pipelines overlapped, the second one's `heroku run` step died with `Cannot run more than 1 Eco size dynos` and failed an otherwise-healthy deploy (observed on the v1.5.3 staging run, which passed on a serial re-run)
+- `deploy-to-staging` and `deploy-to-production` now share the repository-scoped concurrency group `heroku-one-off-dyno`, so one queues behind the other instead of competing. `cancel-in-progress: false` — a deploy interrupted mid-migration is precisely the failure this guards against, so runs wait rather than being killed
+- The guard is scoped to the deploy jobs, not the workflows, so the `test` job still runs in parallel with a production deploy
+
+### ⚠️ Known limitation
+The guard covers GitHub Actions runs only. A manual `heroku run` issued while a deploy is in its migrate/verify phase will still contend for the same dyno — avoid this, or upgrade off Eco dynos to remove the constraint entirely.
+
+**Developer**: Xyrus De Vera
+
+
 ## [1.5.3] - 2026-08-09
 ### 🔧 Deploy Pipeline: Fix Argument Passing to `heroku run`
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-MyTools (The Omnitool) is a Flask-based web application providing various utility tools (tax calculators, character counter, email templates, etc.) with role-based access control. Current version: 1.5.3
+MyTools (The Omnitool) is a Flask-based web application providing various utility tools (tax calculators, character counter, email templates, etc.) with role-based access control. Current version: 1.5.4
 
 ## Frontend Design System (Production — Authoritative)
 
@@ -770,6 +770,7 @@ The CI/CD pipeline (`.github/workflows/deploy.yml`) implements automatic rollbac
 6. **Role spelling mismatch**: The backend stores/serializes the SuperAdmin role as the SQLAlchemy polymorphic identity `"super_admin"` (underscore, see `model/users.py`), but the frontend's role union and every UI check use `"superadmin"` (no underscore). If you add a new place that reads `user.role` from the API, normalize it — see `to_frontend_role`/`to_backend_role` in `services/admin_service.py` (backend) and `normalizeUser` in `frontend/src/lib/api/auth.ts` (frontend). Skipping this makes SuperAdmin-only UI silently fail to render, since `role === "superadmin"` is always `false` for the raw API value.
 7. **Orphaned Alembic revisions after the history squash**: The migration history was squashed into `67f370c787fd_initial_schema` (Jan 2026). Any database whose `alembic_version` still points at a pre-squash revision (e.g. `a1b2c3d4e5f6`) makes **every** Alembic command fail with "Can't locate revision" — including `flask db stamp`, so the only fix is a raw-SQL re-stamp: `UPDATE alembic_version SET version_num='67f370c787fd'` (verify the actual schema matches that baseline first), then `flask db upgrade`. This silently broke prod/staging deploys for months (v1.5.2 outage) because the workflows also ran `heroku run` without `--exit-code`, which always exits 0. Keep `--exit-code` on every `heroku run` step whose failure should fail CI.
 8. **`heroku run` eats your script's flags**: always write `heroku run -a <app> --exit-code -- python scripts/foo.py --env production`. Without the `--` separator the Heroku CLI claims flags it recognizes (`--env`, `--app`, `--size`…) for itself and never passes them to your script, which then silently runs with its *default* arguments. This made `verify_migration.py` run with `--env local` on a production dyno, check a nonexistent SQLite file, and fail a green deploy (v1.5.3).
+9. **Only one Heroku one-off dyno at a time (Eco tier)**: the account allows a single `heroku run` dyno across *all* apps, so concurrent deploys fail with `Cannot run more than 1 Eco size dynos`. The `deploy-to-staging` and `deploy-to-production` jobs share the repository-scoped concurrency group `heroku-one-off-dyno` (v1.5.4) so they queue instead of colliding — keep that group name identical in both workflows if you touch them. The guard does **not** cover manual `heroku run` from a terminal: don't run one while a deploy is in its migrate/verify phase.
 
 # Agent Context & Tooling
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The Omnitool (MyTools)
 
-[![Version](https://img.shields.io/badge/version-1.5.3-blue.svg)](https://github.com/iamxdv30/TheOmnitool/releases)
+[![Version](https://img.shields.io/badge/version-1.5.4-blue.svg)](https://github.com/iamxdv30/TheOmnitool/releases)
 [![Python](https://img.shields.io/badge/python-3.x-3776AB.svg?logo=python&logoColor=white)](https://www.python.org/)
 [![Flask](https://img.shields.io/badge/Flask-3.1.3-000000.svg?logo=flask&logoColor=white)](https://flask.palletsprojects.com/)
 [![Next.js](https://img.shields.io/badge/Next.js-16-000000.svg?logo=next.js&logoColor=white)](https://nextjs.org/)

--- a/VERSION
+++ b/VERSION
@@ -1,2 +1,2 @@
-Current Version: 1.5.3
-Previous Version: 1.5.2
+Current Version: 1.5.4
+Previous Version: 1.5.3


### PR DESCRIPTION
## Summary

**v1.5.4** — serializes the two Heroku deploy jobs so they stop competing for a single dyno. No application code changed.

## Problem

The Heroku account is **Eco tier, which allows exactly one one-off dyno across all apps**. When the staging and production pipelines overlap, whichever reaches its `heroku run` step second dies with:

```
Error: Cannot run more than 1 Eco size dynos.
Error ID: cannot_run_above_limit
```

This failed the v1.5.3 staging run — a deploy that was otherwise completely healthy and passed untouched on a serial re-run. Before v1.5.2 this class of failure was invisible, because `heroku run` exit codes were being discarded.

## Fix

`deploy-to-staging` and `deploy-to-production` now share the repository-scoped concurrency group `heroku-one-off-dyno`, so one queues behind the other instead of colliding.

```yaml
concurrency:
  group: heroku-one-off-dyno
  cancel-in-progress: false
```

Three deliberate choices:

- **Job-level, not workflow-level.** A workflow-level guard would also queue the `test` job behind a production deploy. Tests consume no dynos, so there is no reason to delay that feedback — only the two dyno-consuming jobs need serializing.
- **A fixed literal group name.** The constraint is account-wide, so keying the group on app or branch would defeat it. Concurrency groups are repository-scoped, which is what lets the same string in two separate workflow files serialize against each other.
- **`cancel-in-progress: false`.** The default would kill a running deploy when a new one arrives. Interrupting a deploy mid-`flask db upgrade` is exactly the disaster this guards against, so the second run waits its turn.

## Verification

Both workflow files parse cleanly, with the guard on exactly the intended jobs:

```
deploy.yml
    test                 -> no guard
    deploy-to-staging    -> {'group': 'heroku-one-off-dyno', 'cancel-in-progress': False}
deploy_production.yml
    check-pr-merged      -> no guard
    deploy-to-production -> {'group': 'heroku-one-off-dyno', 'cancel-in-progress': False}
```

## Known limitation

This covers GitHub Actions runs only. A manual `heroku run` issued from a terminal while a deploy is in its migrate/verify phase will still contend for the same dyno. Documented in the CHANGELOG and as CLAUDE.md gotcha #9 rather than left implicit. The complete fix is moving off Eco dynos, which is a billing decision.
